### PR TITLE
fix preferences are double in the db

### DIFF
--- a/server/src/main/java/com/privatechef/preferences/model/PreferencesModel.java
+++ b/server/src/main/java/com/privatechef/preferences/model/PreferencesModel.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ public class PreferencesModel {
     @Id
     private String id;
 
+    @Field("userId")
     @Indexed(unique = true)
     private String userId;
 


### PR DESCRIPTION
This pull request makes a minor update to the `PreferencesModel` class to improve MongoDB field mapping and indexing for the `userId` property.

* Data model improvement:
  * Annotated the `userId` field with `@Field("userId")` to explicitly specify the MongoDB document field name, ensuring consistency and clarity in the database schema.
* Imports update:
  * Added the `org.springframework.data.mongodb.core.mapping.Field` import to support the new annotation.