### PR TITLE
fix token error

### DIFF
--- a/server/src/main/java/com/privatechef/collaboration/CollaborationService.java
+++ b/server/src/main/java/com/privatechef/collaboration/CollaborationService.java
@@ -97,7 +97,7 @@ public class CollaborationService {
 
         CollaborationsUserModel user = getOrCreateCollaborationUser(userId);
 
-        if (!userId.equals(collaboration.getInviteeId())) {
+        if (userId.equals(collaboration.getInviterId())) {
             throw new CollaborationsNotAuthorised(userId);
         }
 

--- a/server/src/test/java/com/privatechef/collaboration/CollaborationServiceTest.java
+++ b/server/src/test/java/com/privatechef/collaboration/CollaborationServiceTest.java
@@ -169,6 +169,7 @@ class CollaborationServiceTest {
         CollaborationsModel collaboration = CollaborationsModel.builder()
                 .id("collabId")
                 .inviteeId("otherUser")
+                .inviterId(userId)
                 .build();
         CollaborationsUserModel user = CollaborationsUserModel.builder().userId(userId).build();
 


### PR DESCRIPTION
This pull request makes a targeted change to the authorization logic in the `CollaborationService`. The update corrects the condition that determines whether a user is authorized to add a collaboration ID, ensuring only the intended users can perform this action.

Authorization logic fix:

* In `CollaborationService.java`, updated the check in `addCollaborationIdToCollaborationsUserReceivedByToken` so that an exception is thrown if the user is the inviter, rather than if the user is not the invitee. This corrects the authorization logic for collaboration actions.